### PR TITLE
Update to java 8u131

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,8 @@ RUN { \
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
-ENV JAVA_VERSION 8u121
-ENV JAVA_DEBIAN_VERSION 8u121-b13-0ubuntu1.16.04.2
+ENV JAVA_VERSION 8u131
+ENV JAVA_DEBIAN_VERSION 8u131-b11-0ubuntu1.16.04.2
 
 # see https://bugs.debian.org/775775
 # and https://github.com/docker-library/java/issues/19#issuecomment-70546872

--- a/README.md
+++ b/README.md
@@ -7,12 +7,16 @@
 
 * Install latest [docker-engine](https://docs.docker.com/engine/installation/) and [docker-compose](https://docs.docker.com/compose/install)
 
+Note: docker-compose version must be >= 1.13.0
+
 # Build docker image
 
 ## Build requirements
 
 * overlayfs-able kernel (for merging the 3 involved docker build contexts)
+* quilt (for appyling patches to the merged docker build context)
 * docker-engine
+
 
 ## Build instructions
 
@@ -22,10 +26,11 @@
 # set correspondingly:
 export PROJECT_DIR=$HOME/Projects/emergya/jenkins-dind
 ln -nfs $PROJECT_DIR/baids $HOME/.baids/functions.d/jenkins-dind
+baids-reload
 ```
 * Build by executing the build baid:
 ```
-jenkins-dind-build-docker-image
+jenkins-dind-docker-build
 ```
 
 # Run/Install
@@ -34,5 +39,16 @@ jenkins-dind-build-docker-image
 export ENV_VHOST=jenkins.emergya.com
 export DATA_DIR=$PWD/data
 docker-compose up -d
+```
+
+* Get jenkins initialAdminPassword:
+```
 docker-compose exec jenkins.emergya.com cat /var/jenkins_home/secrets/initialAdminPassword
 ```
+
+* Get the docker container IP
+```
+docker inspect jenkinsdind_jenkins.emergya.com_1 | grep IPAddress | cut -d '"' -f 4
+```
+
+* Access the jenkins web interface at http://<IP>:8080

--- a/src/quilt-patches/02-set-ubuntus-java-versions.patch
+++ b/src/quilt-patches/02-set-ubuntus-java-versions.patch
@@ -4,15 +4,16 @@ Index: jenkins-dind/Dockerfile
 +++ jenkins-dind/Dockerfile
 @@ -58,11 +58,11 @@ RUN { \
  ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
- 
- ENV JAVA_VERSION 8u121
+
+-ENV JAVA_VERSION 8u121
++ENV JAVA_VERSION 8u131
 -ENV JAVA_DEBIAN_VERSION 8u121-b13-1~bpo8+1
-+ENV JAVA_DEBIAN_VERSION 8u121-b13-0ubuntu1.16.04.2
- 
++ENV JAVA_DEBIAN_VERSION 8u131-b11-0ubuntu1.16.04.2
+
  # see https://bugs.debian.org/775775
  # and https://github.com/docker-library/java/issues/19#issuecomment-70546872
 -ENV CA_CERTIFICATES_JAVA_VERSION 20161107~bpo8+1
 +ENV CA_CERTIFICATES_JAVA_VERSION 20160321
- 
+
  RUN set -x \
  	&& apt-get update \


### PR DESCRIPTION
The previous 8u121 was not available anymore in ubuntu repositories, and caused an error on build.
Updated with current one, both in patches and resulting (automated) Dockerfile.

Also minor updates to README.